### PR TITLE
Checar OS para usar locale correto

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Para rodar:
 ```bash
 python salarios_magistrados.py
 ```
+Um diretório `download` será criado com as planilhas baixadas e `output` com os
+resultados.
 
 ## Possíveis problemas
 
@@ -52,6 +54,3 @@ sudo update-locale
 ```
 
 No Windows, talvez seja necessário instalar os dicionários em Português-Brasil para que funcione corretamente.
-
-Um diretório `download` será criado com as planilhas baixadas e `output` com os
-resultados.

--- a/README.md
+++ b/README.md
@@ -37,5 +37,21 @@ Para rodar:
 python salarios_magistrados.py
 ```
 
+## Possíveis problemas
+
+```locale.Error: unsupported locale setting```
+
+Você não tem a localização pt_BR, que é necessária para que o script funcione corretamente.
+
+No Ubuntu, é possivel resolver com:
+
+```bash
+sudo locale-gen pt_BR
+sudo locale-gen pt_BR.UTF-8
+sudo update-locale
+```
+
+No Windows, talvez seja necessário instalar os dicionários em Português-Brasil para que funcione corretamente.
+
 Um diretório `download` será criado com as planilhas baixadas e `output` com os
 resultados.

--- a/salarios_magistrados.py
+++ b/salarios_magistrados.py
@@ -98,6 +98,14 @@ def extract_metadata(filename):
 
 
 def extract(filename):
+    # Checking OS version to use proper locale
+    if sys.platform.startswith('linux'):
+	    locale = 'pt_BR.UTF-8'
+    elif sys.platform.startswith('win32'):
+        locale = 'ptb_bra'
+    else:
+	    raise ValueError('Platform not tested')
+
     # TODO: check header position
     if filename.name.endswith('.xls'):
         import_function = rows.import_from_xls
@@ -109,7 +117,7 @@ def extract(filename):
     metadata = extract_metadata(filename)
 
     result = []
-    with rows.locale_context('pt_BR.UTF-8'):
+    with rows.locale_context(locale):
         table = import_function(
             str(filename),
             start_row=21,


### PR DESCRIPTION
As strings de locales do Windows e do Linux são diferentes. Essa modificação permite que o script funcione nos dois sem problemas, assumindo que as localizações estão instaladas.

Testado no Windows 10 e no Ubuntu 17.04 (WSL).