### PR TITLE
Allow authomatic missing parents addition on download path

### DIFF
--- a/download_files.py
+++ b/download_files.py
@@ -14,7 +14,7 @@ from utils import fix_tribunal
 
 
 if not settings.DOWNLOAD_PATH.exists():
-    settings.DOWNLOAD_PATH.mkdir()
+    settings.DOWNLOAD_PATH.mkdir(parents=True)
 
 
 class SalariosMagistradosSpider(scrapy.Spider):


### PR DESCRIPTION
I just change the value of `parents` argument in `Path.mkdir` to avoid the error [FileNotFoundError](https://docs.python.org/3/library/exceptions.html#FileNotFoundError).